### PR TITLE
Prevent using v3.x versions of Cloudflare

### DIFF
--- a/ghostbuster/scan.py
+++ b/ghostbuster/scan.py
@@ -17,7 +17,7 @@ from .__init__ import Info, pass_info
 import boto3
 import base64
 import json as json_lib
-import Cloudflare
+import cloudflare
 import awsipranges
 from slack_sdk.webhook import WebhookClient
 from botocore.exceptions import ClientError

--- a/ghostbuster/scan.py
+++ b/ghostbuster/scan.py
@@ -17,7 +17,7 @@ from .__init__ import Info, pass_info
 import boto3
 import base64
 import json as json_lib
-import CloudFlare
+import Cloudflare
 import awsipranges
 from slack_sdk.webhook import WebhookClient
 from botocore.exceptions import ClientError

--- a/ghostbuster/scan.py
+++ b/ghostbuster/scan.py
@@ -17,7 +17,7 @@ from .__init__ import Info, pass_info
 import boto3
 import base64
 import json as json_lib
-import cloudflare
+from cloudflare import Cloudflare
 import awsipranges
 from slack_sdk.webhook import WebhookClient
 from botocore.exceptions import ClientError

--- a/ghostbuster/scan.py
+++ b/ghostbuster/scan.py
@@ -56,7 +56,7 @@ def send_webhook(slackwebhook, takeovers):
 
 def get_cloudflare_records(cloudflaretoken):
     log("Obtaining all zone names from Cloudflare.")
-    cf = CloudFlare.CloudFlare(token=cloudflaretoken, raw=True)
+    cf = CloudFlare(token=cloudflaretoken, raw=True)
     dns_records = []
     # get zone names
     cloudflare_zones = []
@@ -75,7 +75,7 @@ def get_cloudflare_records(cloudflaretoken):
             total_pages = raw_results["result_info"]["total_pages"]
             if page_number == total_pages:
                 break
-    except CloudFlare.exceptions.CloudFlareAPIError as e:
+    except Cloudflare.exceptions.CloudflareAPIError as e:
         exit("Failed to retreive zones %d %s - api call failed" % (e, e))
 
     log("Obtaining DNS A records for all zones from Cloudflare.")
@@ -101,7 +101,7 @@ def get_cloudflare_records(cloudflaretoken):
                 total_pages = raw_results["result_info"]["total_pages"]
                 if page_number == total_pages:
                     break
-        except CloudFlare.exceptions.CloudFlareAPIError as e:
+        except Cloudflare.exceptions.CloudflareAPIError as e:
             exit("Failed to retreive DNS records %d %s - api call failed" % (e, e))
     return dns_records
 

--- a/ghostbuster/scan.py
+++ b/ghostbuster/scan.py
@@ -56,7 +56,7 @@ def send_webhook(slackwebhook, takeovers):
 
 def get_cloudflare_records(cloudflaretoken):
     log("Obtaining all zone names from Cloudflare.")
-    cf = CloudFlare(token=cloudflaretoken, raw=True)
+    cf = Cloudflare(token=cloudflaretoken, raw=True)
     dns_records = []
     # get zone names
     cloudflare_zones = []

--- a/ghostbuster/scan.py
+++ b/ghostbuster/scan.py
@@ -17,7 +17,7 @@ from .__init__ import Info, pass_info
 import boto3
 import base64
 import json as json_lib
-from cloudflare import Cloudflare
+import CloudFlare
 import awsipranges
 from slack_sdk.webhook import WebhookClient
 from botocore.exceptions import ClientError
@@ -56,7 +56,7 @@ def send_webhook(slackwebhook, takeovers):
 
 def get_cloudflare_records(cloudflaretoken):
     log("Obtaining all zone names from Cloudflare.")
-    cf = Cloudflare(token=cloudflaretoken, raw=True)
+    cf = CloudFlare.CloudFlare(token=cloudflaretoken, raw=True)
     dns_records = []
     # get zone names
     cloudflare_zones = []
@@ -75,7 +75,7 @@ def get_cloudflare_records(cloudflaretoken):
             total_pages = raw_results["result_info"]["total_pages"]
             if page_number == total_pages:
                 break
-    except Cloudflare.exceptions.CloudflareAPIError as e:
+    except CloudFlare.exceptions.CloudFlareAPIError as e:
         exit("Failed to retreive zones %d %s - api call failed" % (e, e))
 
     log("Obtaining DNS A records for all zones from Cloudflare.")
@@ -101,7 +101,7 @@ def get_cloudflare_records(cloudflaretoken):
                 total_pages = raw_results["result_info"]["total_pages"]
                 if page_number == total_pages:
                     break
-        except Cloudflare.exceptions.CloudflareAPIError as e:
+        except CloudFlare.exceptions.CloudFlareAPIError as e:
             exit("Failed to retreive DNS records %d %s - api call failed" % (e, e))
     return dns_records
 

--- a/ghostbuster/scan.py
+++ b/ghostbuster/scan.py
@@ -17,7 +17,7 @@ from .__init__ import Info, pass_info
 import boto3
 import base64
 import json as json_lib
-import cloudflare
+import CloudFlare
 import awsipranges
 from slack_sdk.webhook import WebhookClient
 from botocore.exceptions import ClientError

--- a/ghostbuster/scan.py
+++ b/ghostbuster/scan.py
@@ -56,7 +56,7 @@ def send_webhook(slackwebhook, takeovers):
 
 def get_cloudflare_records(cloudflaretoken):
     log("Obtaining all zone names from Cloudflare.")
-    cf = CloudFlare.CloudFlare(token=cloudflaretoken, raw=True)
+    cf = Cloudflare.Cloudflare(token=cloudflaretoken, raw=True)
     dns_records = []
     # get zone names
     cloudflare_zones = []
@@ -75,7 +75,7 @@ def get_cloudflare_records(cloudflaretoken):
             total_pages = raw_results["result_info"]["total_pages"]
             if page_number == total_pages:
                 break
-    except CloudFlare.exceptions.CloudFlareAPIError as e:
+    except Cloudflare.exceptions.CloudflareAPIError as e:
         exit("Failed to retreive zones %d %s - api call failed" % (e, e))
 
     log("Obtaining DNS A records for all zones from Cloudflare.")
@@ -101,7 +101,7 @@ def get_cloudflare_records(cloudflaretoken):
                 total_pages = raw_results["result_info"]["total_pages"]
                 if page_number == total_pages:
                     break
-        except CloudFlare.exceptions.CloudFlareAPIError as e:
+        except Cloudflare.exceptions.CloudflareAPIError as e:
             exit("Failed to retreive DNS records %d %s - api call failed" % (e, e))
     return dns_records
 

--- a/ghostbuster/scan.py
+++ b/ghostbuster/scan.py
@@ -56,7 +56,7 @@ def send_webhook(slackwebhook, takeovers):
 
 def get_cloudflare_records(cloudflaretoken):
     log("Obtaining all zone names from Cloudflare.")
-    cf = Cloudflare.Cloudflare(token=cloudflaretoken, raw=True)
+    cf = CloudFlare.CloudFlare(token=cloudflaretoken, raw=True)
     dns_records = []
     # get zone names
     cloudflare_zones = []
@@ -75,7 +75,7 @@ def get_cloudflare_records(cloudflaretoken):
             total_pages = raw_results["result_info"]["total_pages"]
             if page_number == total_pages:
                 break
-    except Cloudflare.exceptions.CloudflareAPIError as e:
+    except CloudFlare.exceptions.CloudFlareAPIError as e:
         exit("Failed to retreive zones %d %s - api call failed" % (e, e))
 
     log("Obtaining DNS A records for all zones from Cloudflare.")
@@ -101,7 +101,7 @@ def get_cloudflare_records(cloudflaretoken):
                 total_pages = raw_results["result_info"]["total_pages"]
                 if page_number == total_pages:
                     break
-        except Cloudflare.exceptions.CloudflareAPIError as e:
+        except CloudFlare.exceptions.CloudFlareAPIError as e:
             exit("Failed to retreive DNS records %d %s - api call failed" % (e, e))
     return dns_records
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ sphinx-rtd-theme
 tox
 twine
 boto3
-cloudflare
+cloudflare==2.19.*
 awsipranges
 slack_sdk

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         # Include dependencies here
         "click>=7.0,<8",
         "boto3",
-        "cloudflare=2.19.4",
+        "cloudflare==2.19.4",
         "awsipranges",
         "slack_sdk"
     ],

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         # Include dependencies here
         "click>=7.0,<8",
         "boto3",
-        "cloudflare",
+        "cloudflare=2.19.4",
         "awsipranges",
         "slack_sdk"
     ],


### PR DESCRIPTION
Since Cloudflare has start moving there SDKs to v3 (which supports only python 3) workflow seems to be break due to lack of method, class changes (name changes). 
So this PR will only restrict to use v2.19.x cloudflare version until ghostbuster team supports v3.

More Info: 
CF : https://github.com/cloudflare/python-cloudflare/discussions/191
ghostbuter: https://github.com/assetnote/ghostbuster/issues/17